### PR TITLE
修复：payload_to_event 失败时避免 UnboundLocalError

### DIFF
--- a/nonebot/adapters/wxmp/adapter.py
+++ b/nonebot/adapters/wxmp/adapter.py
@@ -180,6 +180,7 @@ class Adapter(BaseAdapter):
             event = self.payload_to_event(bot, payload)
         except Exception as e:
             log("WARNING", f"Failed to parse event {escape_tag(repr(payload))}", e)
+            return Response(200, content="success")
         else:
             task = asyncio.create_task(bot.handle_event(event=event))
             task.add_done_callback(self.tasks.discard)

--- a/tests/test_dispatch_event.py
+++ b/tests/test_dispatch_event.py
@@ -1,0 +1,35 @@
+import asyncio
+from pathlib import Path
+
+import nonebot.adapters
+
+nonebot.adapters.__path__.append(str(Path(__file__).resolve().parents[1] / "nonebot" / "adapters"))
+
+from nonebot.adapters.wxmp.adapter import Adapter
+
+
+class _DummyBotInfo:
+    type = "official"
+
+
+class _DummyBot:
+    bot_info = _DummyBotInfo()
+
+    async def handle_event(self, event):
+        raise AssertionError("handle_event should not be called when payload parsing fails")
+
+
+def test_dispatch_event_parse_error_for_official_bot_returns_success():
+    adapter = object.__new__(Adapter)
+    adapter.tasks = set()
+
+    def _raise_parse_error(bot, payload):
+        raise ValueError("parse failed")
+
+    adapter.payload_to_event = _raise_parse_error
+
+    response = asyncio.run(adapter.dispatch_event(bot=_DummyBot(), payload={}, timeout=0.01))
+
+    assert response.status_code == 200
+    assert response.content == "success"
+    assert not adapter.tasks


### PR DESCRIPTION
## 变更说明
- 当 `payload_to_event` 抛出异常时，立即返回 `200 success`
- 避免在公众号分支中引用未赋值的 `event`，从而规避 `UnboundLocalError`
- 新增回归测试，覆盖“公众号 + 事件解析失败”路径

## 测试
- `.venv/bin/python -m pytest tests/test_dispatch_event.py`

Closes #10
